### PR TITLE
Issue #1: Change DRUPAL_CACHE_PER_ROLE to BACKDROP_CACHE_PER_ROLE.

### DIFF
--- a/wolframAlpha.module
+++ b/wolframAlpha.module
@@ -21,22 +21,22 @@ function wolframAlpha_help($path, $arg) {
 function wolframAlpha_block_info(){
   $blocks['wolframAlpha_size_small'] = array(
     'info' => t('WolframAlpha Small Block'), //The name that will appear in the block list.
-    'cache' => DRUPAL_CACHE_PER_ROLE, //Default
+    'cache' => BACKDROP_CACHE_PER_ROLE, //Default
   );
 
   $blocks['wolframAlpha_size_medium'] = array(
     'info' => t('WolframAlpha Medium Block'), //The name that will appear in the block list.
-    'cache' => DRUPAL_CACHE_PER_ROLE, //Default
+    'cache' => BACKDROP_CACHE_PER_ROLE, //Default
   );
 
   $blocks['wolframAlpha_size_large'] = array(
     'info' => t('WolframAlpha Large Block'), //The name that will appear in the block list.
-    'cache' => DRUPAL_CACHE_PER_ROLE, //Default
+    'cache' => BACKDROP_CACHE_PER_ROLE, //Default
   );
 
   $blocks['wolframAlpha_size_annotated'] = array(
     'info' => t('WolframAlpha Annotated Block'), //The name that will appear in the block list.
-    'cache' => DRUPAL_CACHE_PER_ROLE, //Default
+    'cache' => BACKDROP_CACHE_PER_ROLE, //Default
   );
 
   return $blocks;


### PR DESCRIPTION
This will make it possible for the module to work without the Drupal compatibility layer.